### PR TITLE
[FIX]: Infinite retry to create failed VMs in CostsExample1

### DIFF
--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/costs/CostsExample1.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/costs/CostsExample1.java
@@ -65,7 +65,7 @@ public class CostsExample1 {
     private static final int HOST_PES = 8;
     private static final int HOST_MIPS = 1000;
 
-    private static final int VMS = 4;
+    private static final int VMS = 6;
     private static final int VM_PES = 4;
     private static final int VM_RAM = 512;
     private static final int VM_BW = 1000;
@@ -97,6 +97,9 @@ public class CostsExample1 {
         broker0 = new DatacenterBrokerSimple(simulation);
         //Destroys idle VMs after some time
         broker0.setVmDestructionDelay(0.2);
+        //Disable VMs creation retry
+        //Failed VMs will be just added to the {@link #getVmFailedList()}
+        broker0.setFailedVmsRetryDelay(-1);
 
         vmList = createVms();
         broker0.submitVmList(vmList);

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/costs/CostsExample1.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/costs/CostsExample1.java
@@ -65,7 +65,7 @@ public class CostsExample1 {
     private static final int HOST_PES = 8;
     private static final int HOST_MIPS = 1000;
 
-    private static final int VMS = 6;
+    private static final int VMS = 4;
     private static final int VM_PES = 4;
     private static final int VM_RAM = 512;
     private static final int VM_BW = 1000;


### PR DESCRIPTION
#### What's this Pull Request does, clear and precisely?
This pull request fixes the CostsExample1.java.
The VMs number exceeded the allocation of PEs and the example crashes.
Indeed with
HOST_PES = 8;
VM_PES = 4;
And
VMS = 6;
CloudSim Plus is not able to allocate 4 VM_PES to 6 VMS.

Before the fix:
private static final int VMS = 6;
After the fix:
private static final int VMS = 4;


#### Where should the reviewer start?
private static final int VMS = 4;

